### PR TITLE
Cumulus facts

### DIFF
--- a/library/cumulus_facts
+++ b/library/cumulus_facts
@@ -31,7 +31,7 @@ def run_cl_cmd(module, cmd):
 
 
 def main():
-    module = AnsibleModule()
+    module = AnsibleModule(argument_spec=dict())
     results = dict(
         msg='Collected Cumulus Linux specific facts',
         ansible_facts=dict(

--- a/library/cumulus_facts
+++ b/library/cumulus_facts
@@ -32,7 +32,7 @@ def run_cl_cmd(module, cmd):
 
 def main():
     module = AnsibleModule(argument_spec=dict())
-    platform_detect_exec = '/usr/bin/platform_detect'
+    platform_detect_exec = '/usr/bin/platform-detect'
     results = dict(
         msg='Collected Cumulus Linux specific facts',
         ansible_facts=dict(

--- a/library/cumulus_facts
+++ b/library/cumulus_facts
@@ -9,7 +9,7 @@ module: cumulus_facts
 author: Stanley Karunditu
 short_description: Produces Cumulus Linux specific facts
 description:
-    - Produces Cumulus Linux specific facts. Currently include 'productname' \
+    - Produces Cumulus Linux specific facts. Currently includes 'productname' \
 which refers to the "platform-detect" output.  This module has no options\
 For more details refer to the Cumulus Linux Configuration Guide @ \
 http://docs.cumulusnetworks.com
@@ -19,10 +19,19 @@ options:
             - blank
 '''
 EXAMPLES = '''
-## Get cumulus specific facts
+## Get cumulus specific facts. Currently only gets `platform-detect` output
   - name: get cumulus specific facts
-    cumulus_facts
+    cumulus_facts:
+
+## Run this command only on Penguin Arctica 3200XL. custom fact collected from
+## previous run of `cumulus_facts`
+  - name: setup ports.conf
+    cl_ports:
+        speed_4_by_10g: ['swp1']
+    when: productname == 'cel,smallstone_xp'
 '''
+
+
 def run_cl_cmd(module, cmd):
     (rc, out, err) = module.run_command(cmd, check_rc=False)
     # trim last line as it is always empty

--- a/library/cumulus_facts
+++ b/library/cumulus_facts
@@ -9,12 +9,17 @@ module: cumulus_facts
 author: Stanley Karunditu
 short_description: Produces Cumulus Linux specific facts
 description:
-    - Produces Cumulus Linux specific facts. Currently include 'productname'
+    - Produces Cumulus Linux specific facts. Currently include 'productname' \
 which refers to the "platform-detect" output.  This module has no options\
 For more details refer to the Cumulus Linux Configuration Guide @ \
 http://docs.cumulusnetworks.com
+options:
+    no_options_for_this_module:
+        description:
+            - blank
 '''
 EXAMPLES = '''
+## Get cumulus specific facts
   - name: get cumulus specific facts
     cumulus_facts
 '''

--- a/library/cumulus_facts
+++ b/library/cumulus_facts
@@ -32,10 +32,11 @@ def run_cl_cmd(module, cmd):
 
 def main():
     module = AnsibleModule(argument_spec=dict())
+    platform_detect_exec = '/usr/bin/platform_detect'
     results = dict(
         msg='Collected Cumulus Linux specific facts',
         ansible_facts=dict(
-            productname=run_cl_cmd(module, '/usr/bin/platform-detect')
+            productname=run_cl_cmd(module, platform_detect_exec)[0]
         )
     )
     module.exit_json(**results)

--- a/library/cumulus_facts
+++ b/library/cumulus_facts
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2015, Cumulus Networks www.cumulusnetworks.com
+#
+#
+DOCUMENTATION = '''
+---
+module: cumulus_facts
+author: Stanley Karunditu
+short_description: Produces Cumulus Linux specific facts
+description:
+    - Produces Cumulus Linux specific facts. Currently include 'productname'
+which refers to the "platform-detect" output.  This module has no options\
+For more details refer to the Cumulus Linux Configuration Guide @ \
+http://docs.cumulusnetworks.com
+'''
+EXAMPLES = '''
+  - name: get cumulus specific facts
+    cumulus_facts
+'''
+def run_cl_cmd(module, cmd):
+    (rc, out, err) = module.run_command(cmd, check_rc=False)
+    # trim last line as it is always empty
+    ret = out.splitlines()
+    return ret
+
+
+def main():
+    module = AnsibleModule()
+    results = dict(
+        msg='Collected Cumulus Linux specific facts',
+        ansible_facts=dict(
+            productname=run_cl_cmd(module, '/usr/bin/platform-detect')
+        )
+    )
+    module.exit_json(**results)
+
+
+# import module snippets
+from ansible.module_utils.basic import *
+# from ansible.module_utils.urls import *
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_cumulus_facts.py
+++ b/tests/test_cumulus_facts.py
@@ -1,0 +1,17 @@
+import mock
+from nose.tools import set_trace
+import dev_modules.cumulus_facts as cl_facts
+from asserts import assert_equals
+
+
+@mock.patch('dev_modules.cumulus_facts.run_cl_cmd')
+@mock.patch('dev_modules.cumulus_facts.AnsibleModule')
+def test_running_main(mock_module, mock_cl_cmd):
+    instance = mock_module.return_value
+    mock_cl_cmd.return_value = ['cel,smallstone_xp']
+    cl_facts.main()
+    assert_equals(mock_cl_cmd.call_count, 1)
+    mock_cl_cmd.assert_called_with(instance, '/usr/bin/platform-detect')
+    instance.exit_json.assert_called_with(
+        msg='Collected Cumulus Linux specific facts',
+        ansible_facts={'productname': 'cel,smallstone_xp'})


### PR DESCRIPTION
module created facts for ansible.
```
{ ansible_facts:
       productname: [ output of "platform-detect" string ]
```

This is inline with cumulus puppet facter "productname" variable.

This custom fact may be useful when using the ansible cl_ports (ports.conf) module.

Unit tests written. and tested on real switch to config it works. Here is the test playbook

```
- hosts: all
  tasks:
  - name: get cumulus facts
    cumulus_facts:
    when: ansible_lsb.id == 'Cumulus Networks'

  - name: debug getting product name and using a conditional variable.
    debug: msg={{productname}}
    when: productname  == 'cel,smallstone_xp'
```
