### PR TITLE
Ce 528 missing ports conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *.swp
+ansible.cfg
+site.yml
+ansible.hosts
 *.ropeproject
 *MANIFEST
 *deb_dist

--- a/library/cl_ports
+++ b/library/cl_ports
@@ -58,19 +58,16 @@ def run_cl_cmd(module, cmd, check_rc=True):
 
 def hash_existing_ports_conf(module):
     module.ports_conf_hash = {}
-    if os.path.exists(PORTS_CONF):
-        existing_ports_conf = open(PORTS_CONF).readlines()
-        for _line in existing_ports_conf:
-            m0 = re.match('^(\d+)=(\w+)', _line)
-            if m0:
-                _portnum = int(m0.group(1))
-                _speed = m0.group(2)
-                module.ports_conf_hash[_portnum] = _speed
-    else:
-        _msg = '/etc/cumulus/ports.conf is missing'
-        module.fail_json(msg=_msg, changed=False)
-        # for unit test purposes only
+    if not os.path.exists(PORTS_CONF):
         return False
+
+    existing_ports_conf = open(PORTS_CONF).readlines()
+    for _line in existing_ports_conf:
+        _m0 = re.match(r'^(\d+)=(\w+)', _line)
+        if _m0:
+            _portnum = int(_m0.group(1))
+            _speed = _m0.group(2)
+            module.ports_conf_hash[_portnum] = _speed
 
 
 def generate_new_ports_conf_hash(module):

--- a/library/cl_ports
+++ b/library/cl_ports
@@ -46,16 +46,6 @@ defined in the ports.conf file on Cumulus Linux
 PORTS_CONF = '/etc/cumulus/ports.conf'
 
 
-def run_cl_cmd(module, cmd, check_rc=True):
-    try:
-        (rc, out, err) = module.run_command(cmd, check_rc=check_rc)
-    except Exception, e:
-        module.fail_json(msg=e.strerror)
-    # trim last line as it is always empty
-    ret = out.splitlines()
-    return ret[:-1]
-
-
 def hash_existing_ports_conf(module):
     module.ports_conf_hash = {}
     if not os.path.exists(PORTS_CONF):

--- a/tests/test_cl_ports.py
+++ b/tests/test_cl_ports.py
@@ -165,9 +165,8 @@ def test_hash_existing_ports_conf_doesntwork(mock_module, mock_exists):
     """ test missing ports.conf """
     instance = mock_module.return_value
     mock_exists.return_value = False
-    assert_equals(cl_ports.hash_existing_ports_conf(instance), False)
-    instance.fail_json.assert_called_with(
-        msg='/etc/cumulus/ports.conf is missing', changed=False)
+    cl_ports.hash_existing_ports_conf(instance)
+    assert_equals(instance.ports_conf_hash, {})
 
 
 @mock.patch('dev_modules.cl_ports.os.path.exists')


### PR DESCRIPTION
if ports.conf is missing, don't quit. just create it based on given config parameters.