### PR TITLE
better handling of empty variables in cl_ports

### DIFF
--- a/library/cl_ports
+++ b/library/cl_ports
@@ -72,6 +72,7 @@ def generate_new_ports_conf_hash(module):
         port_range = module.params[k]
         port_setting = convert_hash[k]
         if port_range:
+            port_range = [x for x in port_range if x]
             for port_str in port_range:
                 port_range_str = port_str.replace('swp', '').split('-')
                 if len(port_range_str) == 1:
@@ -91,7 +92,8 @@ def compare_new_and_old_port_conf_hash(module):
     port_num_length = len(module.ports_conf_hash.keys())
     orig_port_num_length = len(ports_conf_hash_copy.keys())
     if port_num_length != orig_port_num_length:
-        module.fail_json(msg="Port numbering is wrong. Too many or two few ports configured")
+        module.fail_json(msg="Port numbering is wrong. \
+Too many or two few ports configured")
         return False
     elif ports_conf_hash_copy == module.ports_conf_hash:
         return False

--- a/tests/test_cl_ports.py
+++ b/tests/test_cl_ports.py
@@ -158,6 +158,13 @@ def test_generate_new_ports_conf_hash(mock_module):
                                             9: '40G/4',
                                             10: '10G'})
 
+    # test if string is empty and none type
+    instance.params = {
+        'speed_40g': [''],
+        'speed_10g': None
+    }
+    cl_ports.generate_new_ports_conf_hash(instance)
+    assert_equals(instance.new_ports_hash, {})
 
 @mock.patch('dev_modules.cl_ports.os.path.exists')
 @mock.patch('dev_modules.cl_ports.AnsibleModule')


### PR DESCRIPTION
remove empty strings from array entries in cl_ports. so if user types speed_40g="", then an empty array is presented to the functions instead of a string.