### PR TITLE
fix striping of whitespace in cl_interface_policy port lists

### DIFF
--- a/library/cl_interface_policy
+++ b/library/cl_interface_policy
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#Copyright (C) 2015, Cumulus Networks www.cumulusnetworks.com
+# Copyright (C) 2015, Cumulus Networks www.cumulusnetworks.com
 #
 #
 DOCUMENTATION = '''
@@ -36,10 +36,13 @@ Example playbook entries using the cl_interface_policy module.
           allowed: "lo eth0 swp1-9, swp11, swp12-13s0, swp12-30s1, swp12-30s2, bond0-12"
 
 '''
+
+
 # get list of interface files that are currently "configured".
 # doesn't mean actually applied to the system, but most likely are
 def read_current_int_dir(module):
     module.custom_currentportlist = os.listdir(module.params.get('location'))
+
 
 # take the allowed list and conver it to into a list
 # of ports.
@@ -50,17 +53,17 @@ def convert_allowed_list_to_port_range(module):
 
 
 def breakout_portrange(prange):
-    m0 = re.match('(\w+[a-z.])(\d+)?-?(\d+)?(\w+)?', prange.strip())
+    _m0 = re.match(r'(\w+[a-z.])(\d+)?-?(\d+)?(\w+)?', prange.strip())
     # no range defined
-    if m0.group(3) is None:
-        return [prange]
+    if _m0.group(3) is None:
+        return [_m0.group(0)]
     else:
         portarray = []
-        intrange = range(int(m0.group(2)), int(m0.group(3)) + 1)
+        intrange = range(int(_m0.group(2)), int(_m0.group(3)) + 1)
         for _int in intrange:
-            portarray.append(''.join([m0.group(1),
+            portarray.append(''.join([_m0.group(1),
                                       str(_int),
-                                      str(m0.group(4) or '')
+                                      str(_m0.group(4) or '')
                                       ]
                                      )
                              )
@@ -75,8 +78,7 @@ def unconfigure_interfaces(module):
     fileprefix = module.params.get('location')
     module.msg = "remove config for interfaces %s" % (', '.join(remove_list))
     for _file in remove_list:
-        os.unlink(fileprefix + _file )
-
+        os.unlink(fileprefix + _file)
 
 
 # check to see if policy should be enforced
@@ -85,7 +87,7 @@ def unconfigure_interfaces(module):
 def int_policy_enforce(module):
     currentportset = set(module.custom_currentportlist)
     allowedportset = set(module.custom_allowedportlist)
-    return not (currentportset.issubset(allowedportset))
+    return not currentportset.issubset(allowedportset)
 
 
 def main():

--- a/tests/test_cl_interface_policy.py
+++ b/tests/test_cl_interface_policy.py
@@ -1,8 +1,8 @@
 import mock
-import os
 from nose.tools import set_trace
 import dev_modules.cl_interface_policy as cl_int_policy
 from asserts import assert_equals
+
 
 @mock.patch('dev_modules.cl_interface_policy.unconfigure_interfaces')
 @mock.patch('dev_modules.cl_interface_policy.convert_allowed_list_to_port_range')
@@ -20,12 +20,13 @@ def test_module_args(mock_module,
                                     'default': '/etc/network/interfaces.d/'}}
     )
 
+
 @mock.patch('dev_modules.cl_interface_policy.os.listdir')
 @mock.patch('dev_modules.cl_interface_policy.AnsibleModule')
 def test_getting_list_of_ports(mock_module, mock_read_dir):
     """ cl_int_policy - get list of current configured ports """
     mock_read_dir.return_value = ['swp1', 'swp2']
-    mock_module.params = { 'location': '/etc/network/interfaces.d' }
+    mock_module.params = {'location': '/etc/network/interfaces.d'}
     cl_int_policy.read_current_int_dir(mock_module)
     mock_read_dir.assert_called_with('/etc/network/interfaces.d')
     assert_equals(mock_module.custom_currentportlist, ['swp1', 'swp2'])
@@ -35,7 +36,7 @@ def test_getting_list_of_ports(mock_module, mock_read_dir):
 def test_breakout_portrange(mock_module):
     """ cl_int_policy - test breaking out port ranges """
     # test single port
-    prange = 'swp1'
+    prange = ' swp1'
     assert_equals(cl_int_policy.breakout_portrange(prange), ['swp1'])
     # range of simple ports
     prange = 'bond0-2'
@@ -50,25 +51,28 @@ def test_breakout_portrange(mock_module):
     prange = 'lo'
     assert_equals(cl_int_policy.breakout_portrange(prange), ['lo'])
 
+
 @mock.patch('dev_modules.cl_interface_policy.AnsibleModule')
 def test_convert_allowed_list_to_port_range(mock_module):
     """ cl_int_policy - test getting allow list """
     mock_module.custom_allowedportlist = []
-    mock_module.params = { 'allowed': ['swp1', 'swp10-11', 'bond0-2'] }
+    mock_module.params = {'allowed': ['swp1', 'swp10-11', 'bond0-2']}
     cl_int_policy.convert_allowed_list_to_port_range(mock_module)
     assert_equals(mock_module.custom_allowedportlist,
-        ['swp1', 'swp10', 'swp11', 'bond0', 'bond1', 'bond2'])
+                  ['swp1', 'swp10', 'swp11', 'bond0', 'bond1', 'bond2'])
+
 
 @mock.patch('dev_modules.cl_interface_policy.AnsibleModule')
-def  test_int_policy_enforce(mock_module):
+def test_int_policy_enforce(mock_module):
     """ cl_int_policy test if enforcing is needed """
-    ## if current list is found in allowed list
+    # if current list is found in allowed list
     mock_module.custom_allowedportlist = ['swp1', 'swp2', 'bond0']
     mock_module.custom_currentportlist = ['swp1', 'swp2']
     assert_equals(cl_int_policy.int_policy_enforce(mock_module), False)
-    ## if current list is nto found in allowed list
+    # if current list is not found in allowed list
     mock_module.custom_currentportlist = ['swp1', 'swp2', 'bond1']
     assert_equals(cl_int_policy.int_policy_enforce(mock_module), True)
+
 
 @mock.patch('dev_modules.cl_interface_policy.os.unlink')
 @mock.patch('dev_modules.cl_interface_policy.AnsibleModule')
@@ -79,4 +83,3 @@ def test_unconfigure_interfaces(mock_module, mock_unlink):
     assert_equals(mock_unlink.call_count, 2)
     assert_equals(mock_module.msg,
                   'remove config for interfaces bond0, bond1')
-


### PR DESCRIPTION
policy fails when i do something like this allowed="lo, eth0". removes eth0 from the
directory. this patch resolves that. plus also did some lint cleanup.