### PR TITLE
document cl_interface, cl_bond and cl_bridge module documentation

### DIFF
--- a/library/cl_bond
+++ b/library/cl_bond
@@ -88,10 +88,20 @@ supported
             - transmit load balancing algorithm. As of Cumulus Linux 2.5 only \
 layer3+4 policy is supported
         default: layer3+4
+    location:
+        description:
+            - interface directory location
+        default:
+            - /etc/network/interfaces.d
+
 
 requirements: [ Alternate Debian network interface manager - \
 ifupdown2 @ github.com/CumulusNetworks/ifupdown2 ]
 notes:
+    - because the module writes the interface directory location. Ensure that \
+``/etc/network/interfaces`` has a 'source /etc/network/interfaces.d/*' \
+or whatever path is mentioned in the ``location`` attribute.
+
     - For the config to be activated, i.e installed in the kernel, \
 "service networking reloaded" needs be be executed. See EXAMPLES section.
 '''

--- a/library/cl_bridge
+++ b/library/cl_bridge
@@ -66,12 +66,24 @@ aware mode, only common instance STP is supported
     mstpctl_treeprio:
         description:
             - set spanning tree root priority. Must be a multiple of 4096
+    location:
+        description:
+            - interface directory location
+        default:
+            - /etc/network/interfaces.d
+
 
 requirements: [ Alternate Debian network interface manager - \
 ifupdown2 @ github.com/CumulusNetworks/ifupdown2 ]
 notes:
+    - because the module writes the interface directory location. Ensure that \
+``/etc/network/interfaces`` has a 'source /etc/network/interfaces.d/*' \
+or whatever path is mentioned in the ``location`` attribute.
+
     - For the config to be activated, i.e installed in the kernel, \
 "service networking reloaded" needs be be executed. See EXAMPLES section.
+
+
 '''
 
 EXAMPLES = '''

--- a/library/cl_interface
+++ b/library/cl_interface
@@ -89,8 +89,13 @@ with 44:38:39:ff. Needs to be the same between 2 Clag switches
 requirements: [ Alternate Debian network interface manager - \
 ifupdown2 @ github.com/CumulusNetworks/ifupdown2 ]
 notes:
+    - because the module writes the interface directory location. Ensure that \
+``/etc/network/interfaces`` has a 'source /etc/network/interfaces.d/*' \
+or whatever path is mentioned in the ``location`` attribute.
+
     - For the config to be activated, i.e installed in the kernel, \
 "service networking reloaded" needs be be executed. See EXAMPLES section.
+
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
to say that the source keyword is required in /etc/network/interfaces