### PR TITLE
Ce 901 io error

### DIFF
--- a/library/cl_ports.py
+++ b/library/cl_ports.py
@@ -111,11 +111,16 @@ Too many or two few ports configured")
         return False
     return True
 
+def make_copy_of_orig_ports_conf(module):
+    if os.path.exists(PORTS_CONF + '.orig'):
+        return
 
-def make_copy_of_orig_ports_conf():
-    if not os.path.exists(PORTS_CONF + '.orig'):
+    try:
         shutil.copyfile(PORTS_CONF, PORTS_CONF + '.orig')
-
+    except IOError as error_msg:
+        _msg = "Failed to save the original %s: %s" % (PORTS_CONF, error_msg)
+        module.fail_json(msg=_msg)
+        return  # for testing only
 
 def write_to_ports_conf(module):
     """

--- a/library/cl_ports.py
+++ b/library/cl_ports.py
@@ -111,6 +111,7 @@ Too many or two few ports configured")
         return False
     return True
 
+
 def make_copy_of_orig_ports_conf(module):
     if os.path.exists(PORTS_CONF + '.orig'):
         return
@@ -138,6 +139,9 @@ def write_to_ports_conf(module):
             temp.write(_str)
         temp.seek(0)
         shutil.copyfile(temp.name, PORTS_CONF)
+    except IOError as error_msg:
+        module.fail_json(
+            msg="Failed to write to %s: %s" % (PORTS_CONF, error_msg))
     finally:
         temp.close()
 

--- a/library/cl_ports.py
+++ b/library/cl_ports.py
@@ -57,7 +57,13 @@ def hash_existing_ports_conf(module):
     if not os.path.exists(PORTS_CONF):
         return False
 
-    existing_ports_conf = open(PORTS_CONF).readlines()
+    try:
+        existing_ports_conf = open(PORTS_CONF).readlines()
+    except IOError as error_msg:
+        _msg = "Failed to open %s: %s" % (PORTS_CONF, error_msg)
+        module.fail_json(msg=_msg)
+        return # for testing only should return on module.fail_json
+
     for _line in existing_ports_conf:
         _m0 = re.match(r'^(\d+)=(\w+)', _line)
         if _m0:

--- a/library/cl_ports.py
+++ b/library/cl_ports.py
@@ -160,7 +160,7 @@ def main():
     hash_existing_ports_conf(module)
     generate_new_ports_conf_hash(module)
     if compare_new_and_old_port_conf_hash(module):
-        make_copy_of_orig_ports_conf()
+        make_copy_of_orig_ports_conf(module)
         write_to_ports_conf(module)
         _changed = True
         _msg = "/etc/cumulus/ports.conf changed"

--- a/tests/test_cl_ports.py
+++ b/tests/test_cl_ports.py
@@ -131,6 +131,16 @@ def test_write_to_ports_conf(mock_module):
 
 
 @mock.patch('library.cl_ports.AnsibleModule')
+def test_write_to_ports_io_error(mock_module):
+    instance = mock_module.return_value
+    with mock.patch('__builtin__.open') as mock_open:
+        mock_open.side_effect = IOError('permission denied')
+        cl_ports.write_to_ports_conf(instance)
+        _msg = 'Failed to write to /etc/cumulus/ports.conf: permission denied'
+        instance.fail_json.assert_called_with(msg=_msg)
+
+
+@mock.patch('library.cl_ports.AnsibleModule')
 def test_compare_new_and_old_port_conf_hash_idempotent(mock_module):
     """ test comparing existing and new ports.conf config """
     instance = mock_module.return_value

--- a/tests/test_cl_ports.py
+++ b/tests/test_cl_ports.py
@@ -18,6 +18,7 @@ def test_module_args(mock_module,
                      mock_write,
                      mock_copy):
     """ cl_ports - Test module argument specs"""
+    instance = mock_module.return_value
     cl_ports.main()
     mock_module.assert_called_with(
         argument_spec={'speed_10g': {'type': 'list'},
@@ -29,6 +30,7 @@ def test_module_args(mock_module,
                           'speed_10g',
                           'speed_40g']]
     )
+    mock_copy.assert_called_with(instance)
 
 
 @mock.patch('library.cl_ports.make_copy_of_orig_ports_conf')

--- a/tests/test_cl_ports.py
+++ b/tests/test_cl_ports.py
@@ -191,3 +191,19 @@ def test_hash_existing_ports_conf_works(mock_module, mock_exists):
         mock_exists.assert_called_with('/etc/cumulus/ports.conf')
         assert_equals(instance.ports_conf_hash[1], '40G')
         assert_equals(instance.ports_conf_hash[11], '4x10G')
+
+@mock.patch('library.cl_ports.os.path.exists')
+@mock.patch('library.cl_ports.AnsibleModule')
+def test_hash_existing_ports_conf_cant_open(mock_module, mock_exists):
+    """ test putting ports.conf values into a hash """
+    # create ansiblemodule mock instance
+    instance = mock_module.return_value
+    # say that ports.conf exists
+    mock_exists.return_value = True
+    with mock.patch('__builtin__.open') as mock_open:
+        mock_open.side_effect = IOError('permission denied')
+        cl_ports.hash_existing_ports_conf(instance)
+        _msg = 'Failed to open /etc/cumulus/ports.conf: permission denied'
+        instance.fail_json.assert_called_with(msg=_msg)
+
+


### PR DESCRIPTION
cover 3 IO failure cases. reading ports.conf, copying ports.conf and writing to ports.conf