### PR TITLE
update tests to check for mixing ipv4 and ipv6 addresses 

### DIFF
--- a/tests/test_cl_bond.py
+++ b/tests/test_cl_bond.py
@@ -161,10 +161,10 @@ def test_build_address(mock_module):
     cl_bond: - test building desired address config
     """
     mock_module.custom_desired_config = {'config': {}}
-    mock_module.params = {'ipv4': ['1.1.1.1/24']}
+    mock_module.params = {'ipv4': ['1.1.1.1/24'], 'ipv6': ['2001:db8:abcd::/48']}
     cl_int.build_address(mock_module)
     assert_equals(mock_module.custom_desired_config,
-                  {'config': {'address': '1.1.1.1/24'}})
+                  {'config': {'address': '1.1.1.1/24 2001:db8:abcd::/48'}})
 
     #
     @mock.patch('library.cl_bond.AnsibleModule')

--- a/tests/test_cl_bridge.py
+++ b/tests/test_cl_bridge.py
@@ -126,10 +126,10 @@ def test_build_address(mock_module):
     cl_bridge: - test building desired address config
     """
     mock_module.custom_desired_config = {'config': {}}
-    mock_module.params = {'ipv4': ['1.1.1.1/24']}
+    mock_module.params = {'ipv4': ['1.1.1.1/24'], 'ipv6': ['2001:db8:abcd::/48']}
     cl_int.build_address(mock_module)
     assert_equals(mock_module.custom_desired_config,
-                  {'config': {'address': '1.1.1.1/24'}})
+                  {'config': {'address': '1.1.1.1/24 2001:db8:abcd::/48'}})
 
     #
 @mock.patch('library.cl_bridge.AnsibleModule')

--- a/tests/test_cl_interface.py
+++ b/tests/test_cl_interface.py
@@ -135,10 +135,10 @@ def test_build_address(mock_module):
     cl_interface: - test building desired address config
     """
     mock_module.custom_desired_config = {'config': {}}
-    mock_module.params = {'ipv4': ['1.1.1.1/24']}
+    mock_module.params = {'ipv4': ['1.1.1.1/24'], 'ipv6': ['2001:db8:abcd::/48']}
     cl_int.build_address(mock_module)
     assert_equals(mock_module.custom_desired_config,
-                  {'config': {'address': '1.1.1.1/24'}})
+                  {'config': {'address': '1.1.1.1/24 2001:db8:abcd::/48'}})
 
     #
 @mock.patch('library.cl_interface.AnsibleModule')


### PR DESCRIPTION
[Cumulus Puppet modules](https://github.com/CumulusNetworks/cumulus-cl-interfaces-puppet/pull/22) had a problem where you cannot mix ipv4 and ipv6 address. added tests to cumulus ansible modules to check for this condition. no change in source code. Just updated
tests.