### PR TITLE
add code to test if ifquery outputs correct text. 

### DIFF
--- a/library/cl_bond.py
+++ b/library/cl_bond.py
@@ -377,6 +377,10 @@ def replace_config(module):
     finally:
         temp.close()
 
+    if desired_config and not final_text:
+        failure_msg = "desired_config not copied into ifupdown2 text format. Not writing config to file"
+        module.fail_json(msg=failure_msg)
+
     try:
         _fh.write(final_text)
     finally:

--- a/library/cl_bridge.py
+++ b/library/cl_bridge.py
@@ -321,6 +321,10 @@ def replace_config(module):
     finally:
         temp.close()
 
+    if desired_config and not final_text:
+        failure_msg = "desired_config not copied into ifupdown2 text format. Not writing config to file"
+        module.fail_json(msg=failure_msg)
+
     try:
         _fh.write(final_text)
     finally:

--- a/library/cl_interface.py
+++ b/library/cl_interface.py
@@ -349,6 +349,10 @@ def replace_config(module):
     finally:
         temp.close()
 
+    if desired_config and not final_text:
+        failure_msg = "desired_config not copied into ifupdown2 text format. Not writing config to file"
+        module.fail_json(msg=failure_msg)
+
     try:
         _fh.write(final_text)
     finally:

--- a/tests/test_cl_bond.py
+++ b/tests/test_cl_bond.py
@@ -317,5 +317,40 @@ def test_config_changed(mock_module):
 
 
 @mock.patch('library.cl_bond.AnsibleModule')
-def test_replace_config(mock_module):
-    pass
+@mock.patch('library.cl_bond.run_cmd')
+def test_replace_config_ifquery_not_outputting_text(mock_run_cmd, mock_module):
+    mock_module.params = {'location': './tests/',
+                          'name': 'swp1'
+                          }
+    mock_module.custom_desired_config = {
+        'name': 'swp1',
+        'addr_method': None,
+        'config':
+        {'address': '10.1.1.2/24',
+         'mtu': '9000'}
+    }
+    mock_run_cmd.return_value = ''
+    mock_module.jsonify = MagicMock(
+        return_value=json.dumps([mock_module.custom_desired_config]))
+    cl_int.replace_config(mock_module)
+    _msg='desired_config not copied into ifupdown2 text format. Not writing config to file'
+    mock_module.fail_json.assert_called_with(msg=_msg)
+
+@mock.patch('library.cl_bond.AnsibleModule')
+@mock.patch('library.cl_bond.run_cmd')
+def test_replace_config_ifquery_not_outputting_text(mock_run_cmd, mock_module):
+    mock_module.params = {'location': './tests/',
+                          'name': 'swp1'
+                          }
+    mock_module.custom_desired_config = {
+        'name': 'swp1',
+        'addr_method': None,
+        'config':
+        {'address': '10.1.1.2/24',
+         'mtu': '9000'}
+    }
+    mock_run_cmd.return_value = 'ifupdown did something'
+    mock_module.jsonify = MagicMock(
+        return_value=json.dumps([mock_module.custom_desired_config]))
+    cl_int.replace_config(mock_module)
+    assert_equals(mock_module.fail_json.call_count, 0)

--- a/tests/test_cl_bridge.py
+++ b/tests/test_cl_bridge.py
@@ -275,8 +275,41 @@ def test_build_desired_iface_config(mock_module,
     assert_equals(mock_bridge.call_count, 4)
     assert_equals(mock_generic.call_count, 2)
 
-
+@mock.patch('library.cl_bridge.AnsibleModule')
+@mock.patch('library.cl_bridge.run_cmd')
+def test_replace_config_ifquery_not_outputting_text(mock_run_cmd, mock_module):
+    mock_module.params = {'location': './tests/',
+                          'name': 'swp1'
+                          }
+    mock_module.custom_desired_config = {
+        'name': 'swp1',
+        'addr_method': None,
+        'config':
+        {'address': '10.1.1.2/24',
+         'mtu': '9000'}
+    }
+    mock_run_cmd.return_value = ''
+    mock_module.jsonify = MagicMock(
+        return_value=json.dumps([mock_module.custom_desired_config]))
+    cl_int.replace_config(mock_module)
+    _msg='desired_config not copied into ifupdown2 text format. Not writing config to file'
+    mock_module.fail_json.assert_called_with(msg=_msg)
 
 @mock.patch('library.cl_bridge.AnsibleModule')
-def test_replace_config(mock_module):
-    pass
+@mock.patch('library.cl_bridge.run_cmd')
+def test_replace_config_ifquery_not_outputting_text(mock_run_cmd, mock_module):
+    mock_module.params = {'location': './tests/',
+                          'name': 'swp1'
+                          }
+    mock_module.custom_desired_config = {
+        'name': 'swp1',
+        'addr_method': None,
+        'config':
+        {'address': '10.1.1.2/24',
+         'mtu': '9000'}
+    }
+    mock_run_cmd.return_value = 'ifupdown did something'
+    mock_module.jsonify = MagicMock(
+        return_value=json.dumps([mock_module.custom_desired_config]))
+    cl_int.replace_config(mock_module)
+    assert_equals(mock_module.fail_json.call_count, 0)


### PR DESCRIPTION
this check will be put in each cl_interface type file to ensure that text is only written if the desired config is actually output as text. this prevents empty config from been written to the network config file.