### PR TITLE
Cumulus facts

### DIFF
--- a/library/cumulus_facts
+++ b/library/cumulus_facts
@@ -31,7 +31,7 @@ def run_cl_cmd(module, cmd):
 
 
 def main():
-    module = AnsibleModule()
+    module = AnsibleModule(argument_spec=dict())
     results = dict(
         msg='Collected Cumulus Linux specific facts',
         ansible_facts=dict(

--- a/library/cumulus_facts
+++ b/library/cumulus_facts
@@ -32,7 +32,7 @@ def run_cl_cmd(module, cmd):
 
 def main():
     module = AnsibleModule(argument_spec=dict())
-    platform_detect_exec = '/usr/bin/platform_detect'
+    platform_detect_exec = '/usr/bin/platform-detect'
     results = dict(
         msg='Collected Cumulus Linux specific facts',
         ansible_facts=dict(

--- a/library/cumulus_facts
+++ b/library/cumulus_facts
@@ -9,7 +9,7 @@ module: cumulus_facts
 author: Stanley Karunditu
 short_description: Produces Cumulus Linux specific facts
 description:
-    - Produces Cumulus Linux specific facts. Currently include 'productname' \
+    - Produces Cumulus Linux specific facts. Currently includes 'productname' \
 which refers to the "platform-detect" output.  This module has no options\
 For more details refer to the Cumulus Linux Configuration Guide @ \
 http://docs.cumulusnetworks.com
@@ -19,10 +19,19 @@ options:
             - blank
 '''
 EXAMPLES = '''
-## Get cumulus specific facts
+## Get cumulus specific facts. Currently only gets `platform-detect` output
   - name: get cumulus specific facts
-    cumulus_facts
+    cumulus_facts:
+
+## Run this command only on Penguin Arctica 3200XL. custom fact collected from
+## previous run of `cumulus_facts`
+  - name: setup ports.conf
+    cl_ports:
+        speed_4_by_10g: ['swp1']
+    when: productname == 'cel,smallstone_xp'
 '''
+
+
 def run_cl_cmd(module, cmd):
     (rc, out, err) = module.run_command(cmd, check_rc=False)
     # trim last line as it is always empty

--- a/library/cumulus_facts
+++ b/library/cumulus_facts
@@ -9,12 +9,17 @@ module: cumulus_facts
 author: Stanley Karunditu
 short_description: Produces Cumulus Linux specific facts
 description:
-    - Produces Cumulus Linux specific facts. Currently include 'productname'
+    - Produces Cumulus Linux specific facts. Currently include 'productname' \
 which refers to the "platform-detect" output.  This module has no options\
 For more details refer to the Cumulus Linux Configuration Guide @ \
 http://docs.cumulusnetworks.com
+options:
+    no_options_for_this_module:
+        description:
+            - blank
 '''
 EXAMPLES = '''
+## Get cumulus specific facts
   - name: get cumulus specific facts
     cumulus_facts
 '''

--- a/library/cumulus_facts
+++ b/library/cumulus_facts
@@ -32,10 +32,11 @@ def run_cl_cmd(module, cmd):
 
 def main():
     module = AnsibleModule(argument_spec=dict())
+    platform_detect_exec = '/usr/bin/platform_detect'
     results = dict(
         msg='Collected Cumulus Linux specific facts',
         ansible_facts=dict(
-            productname=run_cl_cmd(module, '/usr/bin/platform-detect')
+            productname=run_cl_cmd(module, platform_detect_exec)[0]
         )
     )
     module.exit_json(**results)

--- a/library/cumulus_facts
+++ b/library/cumulus_facts
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2015, Cumulus Networks www.cumulusnetworks.com
+#
+#
+DOCUMENTATION = '''
+---
+module: cumulus_facts
+author: Stanley Karunditu
+short_description: Produces Cumulus Linux specific facts
+description:
+    - Produces Cumulus Linux specific facts. Currently include 'productname'
+which refers to the "platform-detect" output.  This module has no options\
+For more details refer to the Cumulus Linux Configuration Guide @ \
+http://docs.cumulusnetworks.com
+'''
+EXAMPLES = '''
+  - name: get cumulus specific facts
+    cumulus_facts
+'''
+def run_cl_cmd(module, cmd):
+    (rc, out, err) = module.run_command(cmd, check_rc=False)
+    # trim last line as it is always empty
+    ret = out.splitlines()
+    return ret
+
+
+def main():
+    module = AnsibleModule()
+    results = dict(
+        msg='Collected Cumulus Linux specific facts',
+        ansible_facts=dict(
+            productname=run_cl_cmd(module, '/usr/bin/platform-detect')
+        )
+    )
+    module.exit_json(**results)
+
+
+# import module snippets
+from ansible.module_utils.basic import *
+# from ansible.module_utils.urls import *
+
+if __name__ == '__main__':
+    main()

--- a/library/cumulus_facts
+++ b/library/cumulus_facts
@@ -7,6 +7,18 @@ def run_cl_cmd(module, cmd):
     ret = out.splitlines()
     return ret
 
+def cl_resource_query(module, facts):
+    (rc, out, err) = module.run_command('/usr/cumulus/bin/cl-resource-query -k')
+    if rc:
+        facts['cumulus_resource_query_facts'] = err
+        return
+    ret = out.splitlines()
+    facts['cumulus_resource_query_facts'] = {}
+    for _line in ret:
+        linesplit = _line.split('=')
+        facts.get('cumulus_resource_query_facts')[linesplit[0]] = linesplit[1]
+
+
 def get_bios_version(module, facts):
     """
     grab bios info from dmesg. Seems to be common across
@@ -77,6 +89,7 @@ def main():
     syseeprom_details(module, results.get('ansible_facts'))
     netshow_system_details(module, results.get('ansible_facts'))
     get_bios_version(module, results.get('ansible_facts'))
+    cl_resource_query(module, results.get('ansible_facts'))
     module.exit_json(**results)
 
 

--- a/library/cumulus_facts
+++ b/library/cumulus_facts
@@ -7,6 +7,23 @@ def run_cl_cmd(module, cmd):
     ret = out.splitlines()
     return ret
 
+def get_bios_version(module, facts):
+    """
+    grab bios info from dmesg. Seems to be common across
+    many cumulus switches. Accuracy unknown . TBD
+    """
+    (rc, out, err) = module.run_command('/bin/dmesg')
+    if rc:
+        facts['cumulus_bios_version'] = err
+        return
+    ret = out.splitlines()
+    for _line in ret:
+        if re.search(' BIOS ', _line):
+            try:
+              facts['cumulus_bios_version'] = _line.split('BIOS')[1].split()[0]
+            except IndexError:
+                pass
+            return
 
 def netshow_system_details(module, facts):
     if not os.path.exists('/usr/bin/netshow'):
@@ -59,6 +76,7 @@ def main():
     )
     syseeprom_details(module, results.get('ansible_facts'))
     netshow_system_details(module, results.get('ansible_facts'))
+    get_bios_version(module, results.get('ansible_facts'))
     module.exit_json(**results)
 
 

--- a/library/cumulus_facts
+++ b/library/cumulus_facts
@@ -8,6 +8,18 @@ def run_cl_cmd(module, cmd):
     return ret
 
 
+def netshow_system_details(module, facts):
+    if not os.path.exists('/usr/bin/netshow'):
+        facts['cumulus_netshow_facts'] = 'install netshow using apt-get install netshow'
+        return
+    (rc, out, err) = module.run_command('/usr/bin/netshow system -j')
+    if rc:
+        facts['cumulus_netshow_facts'] = err
+        return
+    ret = json.loads(out)
+    facts['cumulus_netshow_facts'] = ret.get('system_obj').get('platform_info')
+
+
 def syseeprom_details(module, facts):
     (rc, out, err) = module.run_command('/usr/cumulus/bin/decode-syseeprom')
 
@@ -16,7 +28,7 @@ def syseeprom_details(module, facts):
         return
 
     ret = out.splitlines()
-    start_on_next_line = True
+    start_on_next_line = False
     for _line in ret:
         if _line.startswith('---'):
             start_on_next_line = True
@@ -45,6 +57,7 @@ def main():
         )
     )
     syseeprom_details(module, results.get('ansible_facts'))
+    netshow_system_details(module, results.get('ansible_facts'))
     module.exit_json(**results)
 
 

--- a/library/cumulus_facts
+++ b/library/cumulus_facts
@@ -29,6 +29,7 @@ def syseeprom_details(module, facts):
 
     ret = out.splitlines()
     start_on_next_line = False
+    facts['cumulus_syseeprom_facts'] = dict()
     for _line in ret:
         if _line.startswith('---'):
             start_on_next_line = True
@@ -44,7 +45,7 @@ def syseeprom_details(module, facts):
             if chunk[1].strip().startswith('0x'):
                 header = chunk[0].strip().replace(' ', '_').lower()
                 value = chunk[3].strip()
-                facts['cumulus_syseeprom_' + header] = value
+                facts.get('cumulus_syseeprom_facts')[header] = value
 
 
 def main():

--- a/library/cumulus_facts
+++ b/library/cumulus_facts
@@ -1,35 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright (C) 2015, Cumulus Networks www.cumulusnetworks.com
-#
-#
-DOCUMENTATION = '''
----
-module: cumulus_facts
-author: Stanley Karunditu
-short_description: Produces Cumulus Linux specific facts
-description:
-    - Produces Cumulus Linux specific facts. Currently includes 'productname' \
-which refers to the "platform-detect" output.  This module has no options\
-For more details refer to the Cumulus Linux Configuration Guide @ \
-http://docs.cumulusnetworks.com
-options:
-    no_options_for_this_module:
-        description:
-            - blank
-'''
-EXAMPLES = '''
-## Get cumulus specific facts. Currently only gets `platform-detect` output
-  - name: get cumulus specific facts
-    cumulus_facts:
-
-## Run this command only on Penguin Arctica 3200XL. custom fact collected from
-## previous run of `cumulus_facts`
-  - name: setup ports.conf
-    cl_ports:
-        speed_4_by_10g: ['swp1']
-    when: productname == 'cel,smallstone_xp'
-'''
+#!/usr/bin/python
 
 
 def run_cl_cmd(module, cmd):
@@ -39,15 +8,43 @@ def run_cl_cmd(module, cmd):
     return ret
 
 
+def syseeprom_details(module, facts):
+    (rc, out, err) = module.run_command('/usr/cumulus/bin/decode-syseeprom')
+
+    if rc:
+        facts['cumulus_syseeprom_facts'] = err
+        return
+
+    ret = out.splitlines()
+    start_on_next_line = True
+    for _line in ret:
+        if _line.startswith('---'):
+            start_on_next_line = True
+            continue
+        if start_on_next_line:
+            chunk = []
+            chunk.append(_line[0:21])
+            chunk.append(_line[21:28])
+            chunk.append(_line[28:30])
+            chunk.append(_line[30:])
+            if chunk[0].strip() == 'CRC-32':
+                continue
+            if chunk[1].strip().startswith('0x'):
+                header = chunk[0].strip().replace(' ', '_').lower()
+                value = chunk[3].strip()
+                facts['cumulus_syseeprom_' + header] = value
+
+
 def main():
     module = AnsibleModule(argument_spec=dict())
     platform_detect_exec = '/usr/bin/platform-detect'
     results = dict(
         msg='Collected Cumulus Linux specific facts',
         ansible_facts=dict(
-            productname=run_cl_cmd(module, platform_detect_exec)[0]
+            platform_detect_str=run_cl_cmd(module, platform_detect_exec)[0]
         )
     )
+    syseeprom_details(module, results.get('ansible_facts'))
     module.exit_json(**results)
 
 

--- a/tests/test_cumulus_facts.py
+++ b/tests/test_cumulus_facts.py
@@ -1,0 +1,17 @@
+import mock
+from nose.tools import set_trace
+import dev_modules.cumulus_facts as cl_facts
+from asserts import assert_equals
+
+
+@mock.patch('dev_modules.cumulus_facts.run_cl_cmd')
+@mock.patch('dev_modules.cumulus_facts.AnsibleModule')
+def test_running_main(mock_module, mock_cl_cmd):
+    instance = mock_module.return_value
+    mock_cl_cmd.return_value = ['cel,smallstone_xp']
+    cl_facts.main()
+    assert_equals(mock_cl_cmd.call_count, 1)
+    mock_cl_cmd.assert_called_with(instance, '/usr/bin/platform-detect')
+    instance.exit_json.assert_called_with(
+        msg='Collected Cumulus Linux specific facts',
+        ansible_facts={'productname': 'cel,smallstone_xp'})


### PR DESCRIPTION
create cumulus facts to collect, bios information, system information derived from netshow, system information from decode-syseeprom and cl-resource-query data.

if a particular query fails, like if netshow is not installed or outputs nothing, or dmesg does not have bios info, then the output for that section remains blank. Here is a sample output

```
ansible  -m  cumulus_facts s6000-1
s6000-1 | success >> {
    "ansible_facts": {
        "cumulus_bios_version": "4.6.5", 
        "cumulus_netshow_facts": {
            "chipset": {
                "count": "1", 
                "family": "Trident2 StrataXGS", 
                "manufacturer": "Broadcom", 
                "model": "BCM56850"
            }, 
            "disk": "16GB", 
            "manufacturer": "Dell", 
            "memory": "8GB", 
            "model": "S6000-ON", 
            "odm": "DNI", 
            "ports": "32x40G-QSFP+", 
            "processor": {
                "arch": "x86_64", 
                "cache": {
                    "L1d": "24K", 
                    "L1i": "32K", 
                    "L2": "512K"
                }, 
                "cores": "2", 
                "count": "1", 
                "family": "Atom", 
                "manufacturer": "Intel", 
                "model": "S1220", 
                "speed": "1.60GHz"
            }
        }, 
        "cumulus_resource_query_facts": {
            "ecmp_nh_entry_count": "96", 
            "ecmp_nh_entry_max": "16352", 
            "eg_acl_counter_count": "8", 
            "eg_acl_counter_max": "1024", 
            "eg_acl_entry_count": "4", 
            "eg_acl_entry_max": "256", 
            "eg_acl_meter_count": "4", 
            "eg_acl_meter_max": "256", 
            "eg_acl_slice_count": "1", 
            "eg_acl_slice_max": "1", 
            "host_entry_count": "74", 
            "host_entry_max": "8192", 
            "host_v4_entry_count": "70", 
            "host_v6_entry_count": "2", 
            "in_acl_counter_count": "13", 
            "in_acl_counter_max": "1280", 
            "in_acl_entry_count": "9", 
            "in_acl_entry_max": "1280", 
            "in_acl_meter_count": "4", 
            "in_acl_meter_max": "4096", 
            "in_acl_slice_count": "2", 
            "in_acl_slice_max": "4", 
            "mac_entry_count": "61", 
            "mac_entry_max": "32768", 
            "route_0_entry_count": "130", 
            "route_0_entry_max": "32668", 
            "route_1_entry_count": "25", 
            "route_1_entry_max": "16384", 
            "route_total_entry_count": "155", 
            "route_total_entry_max": "32768", 
            "route_v4_entry_count": "130", 
            "route_v6_entry_count": "25"
        }, 
        "cumulus_syseeprom_facts": "/usr/cumulus/bin/decode-syseeprom : ERROR : must be root to run\n", 
        "platform_detect_str": "dell,s6000_s1220"
    }, 
    "changed": false, 
    "msg": "Collected Cumulus Linux specific facts"
}
```