### PR TITLE
This is a fix to support multiple addresses on an interface.

### DIFF
--- a/library/cl_bond.py
+++ b/library/cl_bond.py
@@ -225,8 +225,7 @@ def build_address(module):
     if _ipv6 and len(_ipv6) > 0:
         _addresslist += _ipv6
     if len(_addresslist) > 0:
-        module.custom_desired_config['config']['address'] = ' '.join(
-            _addresslist)
+        module.custom_desired_config['config']['address'] = _addresslist
 
 
 def build_vids(module):

--- a/library/cl_bridge.py
+++ b/library/cl_bridge.py
@@ -180,8 +180,7 @@ def build_address(module):
     if _ipv6 and len(_ipv6) > 0:
         _addresslist += _ipv6
     if len(_addresslist) > 0:
-        module.custom_desired_config['config']['address'] = ' '.join(
-            _addresslist)
+        module.custom_desired_config['config']['address'] = _addresslist
 
 
 def build_vids(module):

--- a/library/cl_interface.py
+++ b/library/cl_interface.py
@@ -229,8 +229,7 @@ def build_address(module):
     if _ipv6 and len(_ipv6) > 0:
         _addresslist += _ipv6
     if len(_addresslist) > 0:
-        module.custom_desired_config['config']['address'] = ' '.join(
-            _addresslist)
+        module.custom_desired_config['config']['address'] = _addresslist
 
 
 def build_vids(module):


### PR DESCRIPTION
## Pull Request for cl_interface

### Problem description

Let's say we have an dictionary file that looks like this.

~~~
cl_interfaces:
  swp1:
    ipv4: '192.0.2.1/30'
    ipv6: '2001:db8:::1/64'
~~~

Prior to this fix, `cl_interface` creates a file `/etc/network/interfaces.d/swp1` like this.

~~~
auto swp1
iface swp1
  address 192.0.2.1/30 2001:db8:::1/64
~~~

This is because `build_address(module)` joins an array of addresses in `_addresslist` into a string.
These addresses will not be set when you try to bring this interface up.

~~~
# ifup swp1
warning: failed to execute cmd 'ip -force -batch - [addr add 192.0.2.1/30 2001:db8::1/64 dev swp1]'(Error: either "local" is duplicate, or "2001:db8::1/64" is a garbage.)
~~~

By introducing this patch, both IPv4 and IPv6 addresses are configured in separate lines, thus ifupdown2 recognizes both.

~~~
auto swp1
iface swp1
        address 192.0.2.1/30
        address 2001:db8:::1/64
~~~
