### PR TITLE
cl_interface - add bridge_access parameter

### DIFF
--- a/library/cl_interface.py
+++ b/library/cl_interface.py
@@ -55,7 +55,6 @@ options:
     mtu:
         description:
             - set MTU. Configure Jumbo Frame by setting MTU to 9000.
-
     virtual_ip:
         description:
             - define IPv4 virtual IP used by the Cumulus VRR feature
@@ -97,6 +96,9 @@ options:
     pvid:
         description:
             - in vlan aware mode, defines vlan that is the untagged vlan
+    bridge_access:
+        description:
+            - in vlan aware mode, defines an access vlan for the interface
     location:
         description:
             - interface directory location
@@ -134,6 +136,10 @@ notify: reload networking
 
 # configure subinterface with an IP
 cl_interface: name=bond0.100  alias_name='my bond' ipv4=10.1.1.1/24
+notify: reload networking
+
+# configure physical switch port as an access port
+cl_interface: name=swp2 bridge_access=10
 notify: reload networking
 
 # define cl_interfaces once in tasks
@@ -245,6 +251,13 @@ def build_pvid(module):
         module.custom_desired_config['config']['bridge-pvid'] = str(_pvid)
 
 
+def build_bridge_access(module):
+    _bridge_access = module.params.get('bridge_access')
+    if _bridge_access:
+        module.custom_desired_config['config']['bridge_access'] = \
+            str(_bridge_access)
+
+
 def build_speed(module):
     _speed = module.params.get('speed')
     if _speed:
@@ -308,6 +321,7 @@ def build_desired_iface_config(module):
     build_address(module)
     build_vids(module)
     build_pvid(module)
+    build_bridge_access(module)
     build_speed(module)
     build_alias_name(module)
     build_vrr(module)
@@ -383,6 +397,7 @@ def main():
             virtual_mac=dict(type='str'),
             vids=dict(type='list'),
             pvid=dict(type='str'),
+            bridge_access=dict(type='str'),
             mstpctl_portnetwork=dict(type='bool', choices=BOOLEANS),
             mstpctl_portadminedge=dict(type='bool', choices=BOOLEANS),
             mstpctl_bpduguard=dict(type='bool', choices=BOOLEANS),

--- a/tests/test_cl_interface.py
+++ b/tests/test_cl_interface.py
@@ -39,6 +39,7 @@ def test_module_args(mock_module,
             'virtual_ip': {'type': 'str'},
             'vids': {'type': 'list'},
             'pvid': {'type': 'str'},
+            'bridge_access': {'type': 'str'},
             'mstpctl_portnetwork': {'type': 'bool', 'choices': [
                 'yes', 'on', '1', 'true', 1, 'no', 'off', '0', 'false', 0]},
             'mstpctl_portadminedge': {'type': 'bool', 'choices': [
@@ -183,6 +184,18 @@ def test_build_pvid(mock_module):
     cl_int.build_pvid(mock_module)
     assert_equals(mock_module.custom_desired_config,
                   {'config': {'bridge-pvid': '2'}})
+
+
+@mock.patch('library.cl_interface.AnsibleModule')
+def test_build_bridge_access(mock_module):
+    """
+    cl_interface - test building desired bridge_access
+    """
+    mock_module.custom_desired_config = {'config': {}}
+    mock_module.params = {'bridge_access': 2}
+    cl_int.build_bridge_access(mock_module)
+    assert_equals(mock_module.custom_desired_config,
+                  {'config': {'bridge_access': '2'}})
 
 
 @mock.patch('library.cl_interface.AnsibleModule')


### PR DESCRIPTION
**Problem description**

At the moment cl_interface module does not support "bridge_access" parameter. Therefore it is not possible to assign a specific VLAN to a physical port in a vlan-aware bridge. This small patch introduces this parameter. 

Usage example:
`cl_interface: name=swp2 bridge_access=10`

Config created:
<pre>
auto swp2
iface swp2
	bridge_access 10
</pre>