### PR TITLE
Only one VLAN-aware bridge per switch

### DIFF
--- a/tests/acceptance/playbook/tasks/bridges.yml
+++ b/tests/acceptance/playbook/tasks/bridges.yml
@@ -22,7 +22,6 @@
   cl_bridge:
     name: bridge2
     ports: ['swp16-17']
-    vlan_aware: true
   notify: reload networking
 
 - name: New bridge driver over-ride all defaults

--- a/tests/acceptance/spec/default/bridges_spec.rb
+++ b/tests/acceptance/spec/default/bridges_spec.rb
@@ -24,7 +24,6 @@ end
 describe file("#{intf_dir}/bridge2") do
   it { should be_file }
   its(:content) { should match(/iface bridge2/) }
-  its(:content) { should match(/bridge-vlan-aware yes/) }
   its(:content) { should match(/bridge-ports glob swp16-17/) }
   its(:content) { should match(/bridge-stp yes/) }
 end


### PR DESCRIPTION
Since there is only one VLAN-aware bridge allowed per switch (see
https://docs.cumulusnetworks.com/display/CL25/VLAN-aware+Bridge+Mode+for+Large-scale+Layer+2+Environments
 for details), it is probably better not to two of such bridges in a
test playbook.