### PR TITLE
Adjest proper MTU for bridges

### DIFF
--- a/tests/acceptance/playbook/tasks/bridges.yml
+++ b/tests/acceptance/playbook/tasks/bridges.yml
@@ -11,7 +11,6 @@
     ipv4: ['10.0.0.1/24', '192.168.1.0/16']
     ipv6: ['2001:db8:abcd::/48']
     alias_name: 'classic bridge number 1'
-    mtu: 9000
     stp: false
     mstpctl_treeprio: 4096
     virtual_ip: '192.168.100.1'
@@ -22,6 +21,13 @@
   cl_bridge:
     name: bridge2
     ports: ['swp16-17']
+  notify: reload networking
+
+- name: Adjust MTU for ports what are part of bridge3
+  cl_interface:
+    name: "{{ item }}"
+    mtu: 9000
+  with_items: [swp18, swp19]
   notify: reload networking
 
 - name: New bridge driver over-ride all defaults

--- a/tests/acceptance/spec/default/bridges_spec.rb
+++ b/tests/acceptance/spec/default/bridges_spec.rb
@@ -15,7 +15,6 @@ describe file("#{intf_dir}/br1") do
   its(:content) { should match(/iface br1/) }
   its(:content) { should match(/bridge-ports glob swp14-15/) }
   its(:content) { should match(/bridge-stp no/) }
-  its(:content) { should match(/mtu 9000/) }
   its(:content) { should match(/mstpctl-treeprio 4096/) }
   its(:content) { should match(%r{address 10.0.0.1/24 192.168.1.0/16 2001:db8:abcd::/48}) }
 end


### PR DESCRIPTION
If setting MTU on a bridge (bonds too but they adjust automatically),
it should not exceed the smallest MTU value of any ports in that bridge.
Since all of the ports had default MTU (1500) we were erroring out.
Changed so in one case we do not set MTU on a bridge and the other one
where we do, but also adjust ports.