### PR TITLE
Fix for the broken tests

### DIFF
--- a/tests/test_cl_bond.py
+++ b/tests/test_cl_bond.py
@@ -166,7 +166,7 @@ def test_build_address(mock_module):
     mock_module.params = {'ipv4': ['1.1.1.1/24'], 'ipv6': ['2001:db8:abcd::/48']}
     cl_int.build_address(mock_module)
     assert_equals(mock_module.custom_desired_config,
-                  {'config': {'address': '1.1.1.1/24 2001:db8:abcd::/48'}})
+                  {'config': {'address': ['1.1.1.1/24', '2001:db8:abcd::/48']}})
 
     #
     @mock.patch('library.cl_bond.AnsibleModule')

--- a/tests/test_cl_bridge.py
+++ b/tests/test_cl_bridge.py
@@ -133,7 +133,7 @@ def test_build_address(mock_module):
     mock_module.params = {'ipv4': ['1.1.1.1/24'], 'ipv6': ['2001:db8:abcd::/48']}
     cl_int.build_address(mock_module)
     assert_equals(mock_module.custom_desired_config,
-                  {'config': {'address': '1.1.1.1/24 2001:db8:abcd::/48'}})
+                  {'config': {'address': ['1.1.1.1/24', '2001:db8:abcd::/48']}})
 
 
 @mock.patch('library.cl_bridge.AnsibleModule')

--- a/tests/test_cl_interface.py
+++ b/tests/test_cl_interface.py
@@ -145,7 +145,7 @@ def test_build_address(mock_module):
     mock_module.params = {'ipv4': ['1.1.1.1/24'], 'ipv6': ['2001:db8:abcd::/48']}
     cl_int.build_address(mock_module)
     assert_equals(mock_module.custom_desired_config,
-                  {'config': {'address': '1.1.1.1/24 2001:db8:abcd::/48'}})
+                  {'config': {'address': ['1.1.1.1/24', '2001:db8:abcd::/48']}})
 
 
 @mock.patch('library.cl_interface.AnsibleModule')


### PR DESCRIPTION
Hello,

I have notices that some tests are broken at the moment.

```
======================================================================
FAIL: cl_bond: - test building desired address config
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Library/Python/2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Library/Python/2.7/site-packages/mock/mock.py", line 1305, in patched
    return func(*args, **keywargs)
  File "/private/tmp/cumulus-linux-ansible-modules/tests/test_cl_bond.py", line 169, in test_build_address
    {'config': {'address': '1.1.1.1/24 2001:db8:abcd::/48'}})
AssertionError: {'config': {'address': ['1.1.1.1/24', '2001:db8:abcd::/48']}} != {'config': {'address': '1.1.1.1/24 2001:db8:abcd::/48'}}
- {'config': {'address': ['1.1.1.1/24', '2001:db8:abcd::/48']}}
?                        -           ^^^^                   -

+ {'config': {'address': '1.1.1.1/24 2001:db8:abcd::/48'}}
?                                   ^

======================================================================
FAIL: cl_bridge: - test building desired address config
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Library/Python/2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Library/Python/2.7/site-packages/mock/mock.py", line 1305, in patched
    return func(*args, **keywargs)
  File "/private/tmp/cumulus-linux-ansible-modules/tests/test_cl_bridge.py", line 136, in test_build_address
    {'config': {'address': '1.1.1.1/24 2001:db8:abcd::/48'}})
AssertionError: {'config': {'address': ['1.1.1.1/24', '2001:db8:abcd::/48']}} != {'config': {'address': '1.1.1.1/24 2001:db8:abcd::/48'}}
- {'config': {'address': ['1.1.1.1/24', '2001:db8:abcd::/48']}}
?                        -           ^^^^                   -

+ {'config': {'address': '1.1.1.1/24 2001:db8:abcd::/48'}}
?                                   ^

======================================================================
FAIL: cl_interface: - test building desired address config
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Library/Python/2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Library/Python/2.7/site-packages/mock/mock.py", line 1305, in patched
    return func(*args, **keywargs)
  File "/private/tmp/cumulus-linux-ansible-modules/tests/test_cl_interface.py", line 148, in test_build_address
    {'config': {'address': '1.1.1.1/24 2001:db8:abcd::/48'}})
AssertionError: {'config': {'address': ['1.1.1.1/24', '2001:db8:abcd::/48']}} != {'config': {'address': '1.1.1.1/24 2001:db8:abcd::/48'}}
- {'config': {'address': ['1.1.1.1/24', '2001:db8:abcd::/48']}}
?                        -           ^^^^                   -

+ {'config': {'address': '1.1.1.1/24 2001:db8:abcd::/48'}}
?                                   ^

```
As far as I can understand, there is a minor error which is repeated in tests/test_cl_interface.py, tests/test_cl_bridge.py and tests/test_cl_bond.py. As example in tests/test_cl_interface.py we have:

```
147     assert_equals(mock_module.custom_desired_config,
148                   {'config': {'address': '1.1.1.1/24 2001:db8:abcd::/48'}})

```

But, according to library/cl_interface.py

```
226 def build_address(module):
227     # if addr_method == 'dhcp', dont add IP address
228     if module.params.get('addr_method') == 'dhcp':
229         return
230     _ipv4 = module.params.get('ipv4')
231     _ipv6 = module.params.get('ipv6')
232     _addresslist = []
233     if _ipv4 and len(_ipv4) > 0:
234         _addresslist += _ipv4
235     if _ipv6 and len(_ipv6) > 0:
236         _addresslist += _ipv6
237     if len(_addresslist) > 0:
238         module.custom_desired_config['config']['address'] = _addresslist
```

We need a list of strings, not a string with two concatenated ip addresses as it is in the tests, right now.
I think that this patch should fix the tests.